### PR TITLE
FIX: Initialize pedal monitoring pin

### DIFF
--- a/sketches/midi_organ/midi_organ.ino
+++ b/sketches/midi_organ/midi_organ.ino
@@ -127,6 +127,11 @@ void setup() {
       pinMode(manualPins[d], OUTPUT);
       digitalWrite(manualPins[d], HIGH);
   }
+
+  // pedal pin
+  pinMode(pedalPin, OUTPUT)
+  digitalWrite(pedalPin, HIGH)
+
   // initialize the organ keys' pins as inputs
   for(int k=0; k<numKeys; k++){
       pinMode(keyPins[k], INPUT_PULLUP);


### PR DESCRIPTION
This fix actually initializes the pedal pin, in addition to the manual pins, which is required if you want the pedals to do anything.